### PR TITLE
Update Title to display only time without formatting

### DIFF
--- a/src/com/ikovac/timepickerwithseconds/view/MyTimePickerDialog.java
+++ b/src/com/ikovac/timepickerwithseconds/view/MyTimePickerDialog.java
@@ -142,10 +142,10 @@ public class MyTimePickerDialog extends AlertDialog implements OnClickListener,
     }
     
     private void updateTitle(int hour, int minute, int seconds) {
-        mCalendar.set(Calendar.HOUR_OF_DAY, hour);
-        mCalendar.set(Calendar.MINUTE, minute);
-        mCalendar.set(Calendar.SECOND, seconds);
-        setTitle(mDateFormat.format(mCalendar.getTime()) + ":" + String.format("%02d" , seconds));
+        String sHour = String.format("%02d", hour);
+        String sMin = String.format("%02d", minute);
+        String sSec = String.format("%02d", seconds);
+        setTitle(sHour + ":" + sMin + ":" + sSec);
     }
     
     @Override


### PR DESCRIPTION
Earlier it displayed time in format as of '6:30 PM 59', meaning 6:30 in evening and 59 seconds. 
Changed it to just display '18:30:59', now even the user who want to use this as stop watch time selector, can also use it without any problem. 